### PR TITLE
Ignores engines with yarn install and upgrade, resolves #63

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
-RUN yarn install --check-files && yarn upgrade
+RUN yarn install --check-files --ignore-engines && yarn upgrade --ignore-engines 
 
 # Start rails main process
 CMD ["rails","server","-b","0.0.0.0"]


### PR DESCRIPTION
`--ignore-engines` option in yarn commands resolves the errors (and build succeeds) but warnings are still printed about incompatibilities with linux